### PR TITLE
Rebuid DataGenerator located in UnitTests

### DIFF
--- a/pimi-connect-api/pimi-connect-api.API/Migrations/20240420113748_Initialize.Designer.cs
+++ b/pimi-connect-api/pimi-connect-api.API/Migrations/20240420113748_Initialize.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using pimi_connect_app.Data.AppDbContext;
@@ -11,9 +12,11 @@ using pimi_connect_app.Data.AppDbContext;
 namespace pimi_connect_api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240420113748_Initialize")]
+    partial class Initialize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/pimi-connect-api/pimi-connect-api.API/Migrations/20240420113748_Initialize.cs
+++ b/pimi-connect-api/pimi-connect-api.API/Migrations/20240420113748_Initialize.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace pimi_connect_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class Initialize : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedDate",
+                table: "Messages",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SentAt",
+                table: "Emails",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedDate",
+                table: "Messages",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SentAt",
+                table: "Emails",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+        }
+    }
+}

--- a/pimi-connect-api/pimi-connect-api.Data/DbContexts/AppDbContext.cs
+++ b/pimi-connect-api/pimi-connect-api.Data/DbContexts/AppDbContext.cs
@@ -16,7 +16,10 @@ public class AppDbContext : DbContext
     public DbSet<PasswordContainerEntity> PasswordContainers { get; set; }
     public DbSet<UserKeyEntity> UserKeys { get; set; }
 
-    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) 
+    {
+        AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+    }
     
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Base/ControllerUnitTestsBase.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Base/ControllerUnitTestsBase.cs
@@ -119,6 +119,7 @@ public abstract class ControllerUnitTestsBase<TDtoType>  where TDtoType : class
             b => b.MigrationsAssembly(Settings.MigrationsAssemblyName));
 
         TestDbContext = new AppDbContext(optionsBuilder.Options);
+        
     }
     
     #endregion

--- a/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
@@ -106,13 +106,15 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
 
         if (fillDb)
         {
-            //await Helper.FillAttachmentsTable(ExistingIds);
+            await Helper.FillAttachmentsTable(ExistingIds);
             await Helper.FillUsersTable(ExistingIds, ExistingDomains);
         }
         
         // initialize Controller
         var userService = new UserService(TestDbContext, Mapper);
         _userController = new UserController(userService);
+
+        
     }
     
     [Theory]
@@ -203,7 +205,9 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
 
         var newUserName = "updated";
 
-        var userToUpdate = GenerateUserDto(Mapper, userExists ? ExistingDomain : NotExistingDomain ,userExists ? ExistingId : NotExistingId);
+        var existingAttachmentId = ExistingIds.Where(x => x != ExistingId).FirstOrDefault();
+
+        var userToUpdate = GenerateUserDto(Mapper, userExists ? ExistingDomain : NotExistingDomain ,userExists ? ExistingId : NotExistingId, userExists ? existingAttachmentId : null);
         userToUpdate.UserName = newUserName;
 
         // Act && Assert

--- a/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
@@ -8,15 +8,106 @@ namespace pimi_connect_api.UnitTests.ControllersTests;
 public class UserControllerTests : ControllerUnitTestsBase<UserDto>
 {
     private UserController _userController;
-    
+    private List<string> ExistingDomains;
+    private string ExistingDomain;
+    private string NotExistingDomain;
+    private new Guid ExistingId { get; set; }
+
+    private List<string> emailDomains = new List<string>
+        {
+            "gmail.com",
+            "yahoo.com",
+            "hotmail.com",
+            "outlook.com",
+            "example.com",
+            "aol.com",
+            "icloud.com",
+            "protonmail.com",
+            "mail.com",
+            "live.com",
+            "msn.com",
+            "yandex.com",
+            "zoho.com",
+            "rocketmail.com",
+            "gmx.com",
+            "inbox.com",
+            "me.com",
+            "fastmail.com",
+            "yahoo.co.uk",
+            "ymail.com",
+            "att.net",
+            "cox.net",
+            "comcast.net",
+            "sbcglobal.net",
+            "roadrunner.com",
+            "verizon.net",
+            "earthlink.net",
+            "mac.com",
+            "qq.com",
+            "163.com",
+            "126.com",
+            "sina.com",
+            "sohu.com",
+            "hotmail.co.uk",
+            "btinternet.com",
+            "ntlworld.com",
+            "blueyonder.co.uk",
+            "talktalk.net",
+            "virginmedia.com",
+            // Add more domains as needed
+        };
+
+    #region Setup methods
+
+    private void SetDomains()
+    {
+        SetExistingDomains();
+        SetExistingDomain();
+        SetNotExistingDomain();
+    }
+
+    private void SetExistingDomains()
+    {
+        
+        var r = new Random();
+
+        ExistingDomains = new List<string>();
+
+        for (var i = 0; i < Settings.EntitiesCount; i++)
+        {
+            ExistingDomains.Add(emailDomains[r.Next(emailDomains.Count)]);
+        }
+    }
+
+    private void SetExistingDomain()
+    {
+        var r = new Random();
+        int randomNumber = r.Next(0, ExistingIds.Count);
+
+        ExistingDomain = ExistingDomains[randomNumber];
+        ExistingId = ExistingIds[randomNumber];
+    }
+
+    private void SetNotExistingDomain()
+    {
+        var r = new Random();
+        var notExistingDomains = emailDomains.Where(d => !ExistingDomains.Contains(d)).ToList();
+        var newDomain = notExistingDomains[r.Next(notExistingDomains.Count)];
+
+        NotExistingDomain = newDomain;
+    }
+
+    #endregion
+
     private new async Task Arrange(bool fillDb = true)
     {
         await base.Arrange();
+        SetDomains();
 
         if (fillDb)
         {
             await Helper.FillAttachmentsTable(ExistingIds);
-            await Helper.FillUsersTable(ExistingIds);
+            await Helper.FillUsersTable(ExistingIds, ExistingDomains);
         }
         
         // initialize Controller
@@ -58,8 +149,8 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
         await Arrange();
 
         var email = emailExists ? 
-            GenerateEmail(ExistingId) : 
-            GenerateEmail(NotExistingId);
+            GenerateEmail(ExistingDomain,ExistingId) : 
+            GenerateEmail(NotExistingDomain,NotExistingId);
         
         // Act && Assert
         if (emailExists)
@@ -112,7 +203,7 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
 
         var newUserName = "updated";
 
-        var userToUpdate = GenerateUserDto(Mapper, userExists ? ExistingId : NotExistingId);
+        var userToUpdate = GenerateUserDto(Mapper, userExists ? ExistingDomain : NotExistingDomain ,userExists ? ExistingId : NotExistingId);
         userToUpdate.UserName = newUserName;
 
         // Act && Assert
@@ -156,7 +247,7 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
         {
             Id = idAlreadyExists ? ExistingId : NotExistingId,
             UserName = GenerateUserName(),
-            Email = GenerateEmail(emailAlreadyExists ? ExistingId : NotExistingId),
+            Email = GenerateEmail(emailAlreadyExists ? ExistingDomain : NotExistingDomain,emailAlreadyExists ? ExistingId : NotExistingId),
             Status = UserStatus.Accessible,
             ProfilePictureId = ExistingId
         };

--- a/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/ControllersTests/UserControllerTests.cs
@@ -106,7 +106,7 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
 
         if (fillDb)
         {
-            await Helper.FillAttachmentsTable(ExistingIds);
+            //await Helper.FillAttachmentsTable(ExistingIds);
             await Helper.FillUsersTable(ExistingIds, ExistingDomains);
         }
         
@@ -292,6 +292,7 @@ public class UserControllerTests : ControllerUnitTestsBase<UserDto>
         // Act && Assert
         if (userExists)
         {
+            ;
             var result = await _userController.DeleteAsync(ExistingId);
             var resultTuple = GetStatusAndContentFromResult(result);
 

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -9,27 +9,28 @@ public static class DataGenerator
     {
         return $"user{id}";
     }
-    
-    public static string GenerateEmail(Guid id = new ())
-    {
-        return $"user{id}@domain.com";
+
+    public static string GenerateEmail(string domain, Guid id = new())
+    { 
+
+        return $"user{id}@{domain}";
     }
-    
-    public static UserEntity GenerateUserEntity(Guid id = new ())
+
+    public static UserEntity GenerateUserEntity(string domain, Guid id = new ())
     {
         return new UserEntity()
         {
             Id = id,
             UserName = GenerateUserName(id),
-            Email = GenerateEmail(id),
+            Email = GenerateEmail(domain,id),
             Status = UserStatus.Accessible,
             ProfilePictureId = id
         };
     }
     
-    public static UserDto GenerateUserDto(IMapper mapper, Guid id = new ())
+    public static UserDto GenerateUserDto(IMapper mapper, string domain, Guid id = new ())
     {
-        var userEntity = GenerateUserEntity(id);
+        var userEntity = GenerateUserEntity(domain, id);
 
         return mapper.Map<UserDto>(userEntity);
     }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -213,7 +213,7 @@ public static class DataGenerator
 
         };
 
-        userChatEntity.LastReadMessage = GenerateMessageEntity(userChatEntity, lastmessageID);
+        //userChatEntity.LastReadMessage = GenerateMessageEntity(userChatEntity, lastmessageID);
 
         return userChatEntity;
     }
@@ -299,6 +299,36 @@ public static class DataGenerator
             IndirectKey = GenerateRandomBytes(32)
         };
     }
+
+    #endregion
+
+    #region Generate Email related data
+
+    public static EmailEntity GenerateEmailEntity(Guid id = new ())
+    {
+        return new EmailEntity
+        {
+            Id = id,
+            To = $"user{id}",
+            Subject = $"subject{id}",
+            Template = EmailTemplate.NewAccount,
+            SentAt = DateTime.Now
+        };
+    }
+
+    // EmailDto does not exist
+    /* public static EmailDto GenerateEmailDto(IMapper mapper, Guid id = new ())
+     {
+         var emailEntity = GenerateEmailEntity(id);  
+
+         return mapper.Map<EmailDto>(emailEntity);
+     }*/
+
+    #endregion
+
+    #region Generate Chat related data
+
+    //Methods in ChatEntity branch
 
     #endregion
 }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -215,4 +215,51 @@ public static class DataGenerator
     }
 
     #endregion
+
+    #region Generate Message related data
+
+    public static MessageEntity GenerateMessageEntity(UserChatEntity userChat, Guid id = new ())
+    {
+        var userCreatedID = Guid.NewGuid();
+        var attachmentID = Guid.NewGuid();
+        var passwordContainerID = Guid.NewGuid();
+        var attachment = GenerateAttachmentEntity(attachmentID);
+        return new MessageEntity
+        {
+            Id = id,
+            Content = $"content{id}",
+            CreatedDate = DateTime.Now,
+            ChatId = userChat.ChatId,
+            UserCreatedId = userChat.UserId,
+            AttachmentId = attachmentID,
+            PasswordContainerId = passwordContainerID,
+            //Chat = GenerateChatEntity(chatID),
+            UserCreated = GenerateUserEntity("gmail.com", userCreatedID),
+            Attachments = new List<AttachmentEntity> { attachment },
+            PasswordContainer = GeneratePasswordContainerEntity(userChat.ChatId,passwordContainerID)
+        };
+    }
+
+    public static MessageDto GenerateMessageDto(IMapper mapper, UserChatEntity userChat, Guid id = new ())
+    {
+        var messageEntity = GenerateMessageEntity(userChat, id);
+
+        return mapper.Map<MessageDto>(messageEntity);
+    }
+
+    #endregion
+
+    #region Generate PasswordContainer related data
+
+    public static PasswordContainerEntity GeneratePasswordContainerEntity(Guid chatID,Guid id = new ())
+    {
+        return new PasswordContainerEntity
+        {
+            Id = id,
+            ChatId = chatID,
+            //ChatPassword = GenerateChatPassword()
+        };
+    }
+
+    #endregion
 }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -63,16 +63,18 @@ public static class DataGenerator
 
     public static UserEntity GenerateUserEntity(string domain, Guid id = new ())
     {
+        var profilePictureId = Guid.NewGuid();
+        var authId = Guid.NewGuid();
         var userEntity = new UserEntity()
         {
             Id = id,
             UserName = GenerateUserName(id),
             Email = GenerateEmail(domain, id),
             Status = UserStatus.Accessible,
-            ProfilePictureId = id,
-            Auth = GenerateAuthEntity(id),
-            ProfilePicture = GenerateAttachmentEntity(),
-            //UserChats
+            ProfilePictureId = profilePictureId,
+            Auth = GenerateAuthEntity(authId),
+            ProfilePicture = GenerateAttachmentEntity(profilePictureId, AttachmentType.ProfilePicture),
+            //UserChats = new List<UserChatEntity>(),
             Messages = new List<MessageEntity>()
 
         };
@@ -169,14 +171,14 @@ public static class DataGenerator
         string path = $"/{fileTypePrefixes.Keys.ElementAt(randomNumber)}/{fileName}";
         return new Tuple<string,string>(fileName, path);
     }
-    public static AttachmentEntity GenerateAttachmentEntity(Guid id = new ())
+    public static AttachmentEntity GenerateAttachmentEntity(Guid id = new (), AttachmentType type = AttachmentType.MessageAttachment)
     {
         var fileNameAndPath = GenerateFileNameAndPath(id);
 
         return new AttachmentEntity
         {
             Id = id,
-            Type = AttachmentType.MessageAttachment,
+            Type = type,
             Extension = GenerateExtension(),
             Path = fileNameAndPath.Item2,
             publicName = fileNameAndPath.Item1
@@ -236,12 +238,10 @@ public static class DataGenerator
 
     public static MessageEntity GenerateMessageEntity(UserChatEntity userChat, Guid id = new ())
     {
-        var userCreatedID = Guid.NewGuid();
+        
         var attachmentID = Guid.NewGuid();
         var passwordContainerID = Guid.NewGuid();
         var attachment = GenerateAttachmentEntity(Guid.NewGuid());
-        var userTest = userChat.User;
-        var passwordContainerTest = GeneratePasswordContainerEntity(userChat.ChatId, passwordContainerID);
 
         return new MessageEntity
         {
@@ -253,9 +253,9 @@ public static class DataGenerator
             AttachmentId = attachmentID,
             PasswordContainerId = passwordContainerID,
             Chat = userChat.Chat,
-            UserCreated = userTest,
+            UserCreated = userChat.User,
             Attachments = new List<AttachmentEntity> { attachment },
-            PasswordContainer = passwordContainerTest
+            PasswordContainer = GeneratePasswordContainerEntity(userChat.ChatId, passwordContainerID)
         };
     }
 

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -54,27 +54,39 @@ public static class DataGenerator
         return new AuthEntity()
         {
             Id = id,
-            PasswordSalt = salt,
+            PrivateKey = GenerateRandomBytes(32),
             PasswordHash = GeneratePassword(salt),
-            PrivateKey = GenerateRandomBytes(32)
+            PasswordSalt = salt
+
         };
     }
 
     public static UserEntity GenerateUserEntity(string domain, Guid id = new ())
     {
-        return new UserEntity()
+        var userEntity = new UserEntity()
         {
             Id = id,
             UserName = GenerateUserName(id),
-            Email = GenerateEmail(domain,id),
+            Email = GenerateEmail(domain, id),
             Status = UserStatus.Accessible,
             ProfilePictureId = id,
             Auth = GenerateAuthEntity(id),
-            ProfilePicture = GenerateAttachmentEntity(id)
+            ProfilePicture = GenerateAttachmentEntity(),
             //UserChats
-            //Messages
-            
+            Messages = new List<MessageEntity>()
+
         };
+        var userChatEntity = GenerateUserChatEntity(userEntity);
+        userEntity.Messages.Add(GenerateMessageEntity(userChatEntity));
+
+        /*for (int i = 0; i < 5; i++)
+        {
+            
+            //userEntity.UserChats.Add(GenerateUserChatEntity(userEntity));
+            
+        }*/
+
+        return userEntity;
     }
     
     public static UserDto GenerateUserDto(IMapper mapper, string domain, Guid id = new ())
@@ -185,21 +197,25 @@ public static class DataGenerator
     {
         var chatID = Guid.NewGuid();
         var lastmessageID = Guid.NewGuid();
-        var userKeyID = Guid.NewGuid();
-        return new UserChatEntity
+        var userKey = GenerateUserKeyEntity();
+
+        var userChatEntity = new UserChatEntity
         {
             Id = id,
             UserId = user.Id,
             ChatId = chatID,
             LastReadMessageId = lastmessageID,
             NickName = GenerateNickName(id),
-            //LastReadMessage = GenerateMessageEntity(lastmessageID),
             Role = ChatRole.Admin,
             User = user,
             //Chat = GenerateChatEntity(chatID),
-            UserKeyId = userKeyID
+            UserKeyId = userKey.Id
 
         };
+
+        userChatEntity.LastReadMessage = GenerateMessageEntity(userChatEntity, lastmessageID);
+
+        return userChatEntity;
     }
 
     public static UserChatDto GenerateUserChatDto(IMapper mapper, UserEntity user, Guid id = new ())
@@ -257,7 +273,30 @@ public static class DataGenerator
         {
             Id = id,
             ChatId = chatID,
-            //ChatPassword = GenerateChatPassword()
+            //ChatPassword = new List<ChatPasswordEntity>() { GenerateChatPasswordEntity() }
+        };
+    }
+
+    public static ChatPasswordEntity GenerateChatPasswordEntity(Guid id = new ())
+    {
+        return new ChatPasswordEntity
+        {
+            PasswordContainerId = id,
+            PasswordHash = GenerateRandomBytes(32),
+            UserId = Guid.NewGuid()
+        };
+    }
+
+    #endregion
+
+    #region Generate UserKey related data
+
+    public static UserKeyEntity GenerateUserKeyEntity(Guid id = new ())
+    {
+        return new UserKeyEntity
+        {
+            Id = id,
+            IndirectKey = GenerateRandomBytes(32)
         };
     }
 

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -37,15 +37,88 @@ public static class DataGenerator
     #endregion
     
     #region Generate Attachment related data
+
+    private static string GenerateExtension()
+    {
+        var r = new Random();
+        List<string> mediaFileExtensions = new List<string>
+        {
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".aac",
+            ".ogg",
+            ".wma",
+            ".m4a",
+            ".mp4",
+            ".avi",
+            ".mkv",
+            ".mov",
+            ".wmv",
+            ".flv",
+            ".webm",
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".bmp",
+            ".tiff",
+            ".svg",
+            ".mpg",
+            ".mpeg",
+            ".mpe",
+            ".mp2",
+            ".mpv",
+            ".m4v",
+            ".ogg",
+            ".oga",
+            ".ogv",
+            ".opus",
+            ".ico",
+            ".pdf",
+            ".doc",
+            ".docx",
+            ".xls",
+            ".xlsx",
+            ".ppt",
+            ".pptx",
+            // Add more extensions as needed
+        };
+
+        return mediaFileExtensions[r.Next(mediaFileExtensions.Count)];
+    }
+
+    private static Tuple<string, string> GenerateFileNameAndPath(Guid id = new())
+    {
+        Dictionary<string, string> fileTypePrefixes = new Dictionary<string, string>
+        {
+            { "Songs", "Song" },
+            { "Videos", "Video" },
+            { "Documents", "Doc" },
+            { "Images", "Image" },
+            { "Clips", "Clip" },
+            { "Media", "Media" },
+            { "Audio", "Audio" },
+            { "Files", "File"}
+        };
+
+        var r = new Random();
+        int randomNumber = r.Next(fileTypePrefixes.Count);
+        string fileName = $"{fileTypePrefixes.Values.ElementAt(randomNumber)}{id}";
+        string path = $"/{fileTypePrefixes.Keys.ElementAt(randomNumber)}/{fileName}";
+        return new Tuple<string,string>(fileName, path);
+    }
     public static AttachmentEntity GenerateAttachmentEntity(Guid id = new ())
     {
+        var fileNameAndPath = GenerateFileNameAndPath(id);
+
         return new AttachmentEntity
         {
             Id = id,
             Type = AttachmentType.ProfilePicture,
-            Extension = ".jpg",
-            Path = "/some/path",
-            publicName = "publicName"
+            Extension = GenerateExtension(),
+            Path = fileNameAndPath.Item2,
+            publicName = fileNameAndPath.Item1
         };
     }
     

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -28,6 +28,38 @@ public static class DataGenerator
         return $"user{id}@{domain}";
     }
 
+    public static byte[] GeneratePassword(byte[] salt)
+    {
+        Random r = new Random();
+        int lenght = r.Next(8, 16);
+        string password = string.Empty;
+        for (int i = 0; i < lenght; i++)
+        {
+            password += (char)r.Next(33, 126);
+        }
+
+        byte[] passwordHashed;
+
+        using(SHA256 sha256 = SHA256.Create())
+        {
+            passwordHashed = sha256.ComputeHash(Encoding.ASCII.GetBytes(password + Convert.ToBase64String(salt)));
+        }
+
+        return passwordHashed;
+    }
+
+    public static AuthEntity GenerateAuthEntity(Guid id = new ())
+    {
+        byte[] salt = GenerateRandomBytes(16);
+        return new AuthEntity()
+        {
+            Id = id,
+            PasswordSalt = salt,
+            PasswordHash = GeneratePassword(salt),
+            PrivateKey = GenerateRandomBytes(32)
+        };
+    }
+
     public static UserEntity GenerateUserEntity(string domain, Guid id = new ())
     {
         return new UserEntity()

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -1,10 +1,22 @@
 using AutoMapper;
+using System;
+using System.Runtime.Intrinsics.Arm;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace pimi_connect_api.UnitTests.Shared;
 
 public static class DataGenerator
 {
     #region Generate User related data
+    private static byte[] GenerateRandomBytes(int length)
+    {
+        var random = new Random();
+        byte[] buffer = new byte[length];
+        random.NextBytes(buffer);
+        return buffer;
+    }
+
     public static string GenerateUserName(Guid id = new ())
     {
         return $"user{id}";

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -61,24 +61,28 @@ public static class DataGenerator
         };
     }
 
-    public static UserEntity GenerateUserEntity(string domain, Guid id = new ())
+    public static UserEntity GenerateUserEntity(string domain, Guid id = new (), Guid? profilePictureId = null)
     {
-        var profilePictureId = Guid.NewGuid();
+        if(profilePictureId == null) profilePictureId = Guid.NewGuid();
+
         var authId = Guid.NewGuid();
+        var profilePicture = GenerateAttachmentEntity((Guid)profilePictureId, AttachmentType.ProfilePicture);
+
         var userEntity = new UserEntity()
         {
             Id = id,
             UserName = GenerateUserName(id),
             Email = GenerateEmail(domain, id),
             Status = UserStatus.Accessible,
-            ProfilePictureId = profilePictureId,
+            ProfilePictureId = (Guid)profilePictureId,
             Auth = GenerateAuthEntity(authId),
-            ProfilePicture = GenerateAttachmentEntity(profilePictureId, AttachmentType.ProfilePicture),
+            ProfilePicture = profilePicture,
             //UserChats = new List<UserChatEntity>(),
             Messages = new List<MessageEntity>()
 
         };
         var userChatEntity = GenerateUserChatEntity(userEntity);
+        //userEntity.UserChats.Add(userChatEntity);
         userEntity.Messages.Add(GenerateMessageEntity(userChatEntity));
 
         /*for (int i = 0; i < 5; i++)
@@ -91,9 +95,9 @@ public static class DataGenerator
         return userEntity;
     }
     
-    public static UserDto GenerateUserDto(IMapper mapper, string domain, Guid id = new ())
+    public static UserDto GenerateUserDto(IMapper mapper, string domain, Guid id = new (), Guid? profilePictureId = null)
     {
-        var userEntity = GenerateUserEntity(domain, id);
+        var userEntity = GenerateUserEntity(domain, id, profilePictureId);
 
         return mapper.Map<UserDto>(userEntity);
     }
@@ -241,7 +245,7 @@ public static class DataGenerator
         
         var attachmentID = Guid.NewGuid();
         var passwordContainerID = Guid.NewGuid();
-        var attachment = GenerateAttachmentEntity(Guid.NewGuid());
+        var attachment = GenerateAttachmentEntity(attachmentID);
 
         return new MessageEntity
         {
@@ -254,7 +258,7 @@ public static class DataGenerator
             PasswordContainerId = passwordContainerID,
             Chat = userChat.Chat,
             UserCreated = userChat.User,
-            Attachments = new List<AttachmentEntity> { attachment },
+            //Attachments = new List<AttachmentEntity> { attachment }, Przy usuwaniu u¿ytkownika:  modyfikacja lub usuniêcie na tabeli "Messages" narusza klucz obcy "FK_Attachments_Messages_MessageEntityId" tabeli "Attachments"
             PasswordContainer = GeneratePasswordContainerEntity(userChat.ChatId, passwordContainerID)
         };
     }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -68,7 +68,12 @@ public static class DataGenerator
             UserName = GenerateUserName(id),
             Email = GenerateEmail(domain,id),
             Status = UserStatus.Accessible,
-            ProfilePictureId = id
+            ProfilePictureId = id,
+            Auth = GenerateAuthEntity(id),
+            ProfilePicture = GenerateAttachmentEntity(id)
+            //UserChats
+            //Messages
+            
         };
     }
     

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -178,4 +178,41 @@ public static class DataGenerator
         return mapper.Map<AttachmentDto>(attachmentEntity);
     }
     #endregion
+
+    #region Generate UserChat related data
+
+    public static UserChatEntity GenerateUserChatEntity(UserEntity user, Guid id = new ())
+    {
+        var chatID = Guid.NewGuid();
+        var lastmessageID = Guid.NewGuid();
+        var userKeyID = Guid.NewGuid();
+        return new UserChatEntity
+        {
+            Id = id,
+            UserId = user.Id,
+            ChatId = chatID,
+            LastReadMessageId = lastmessageID,
+            NickName = GenerateNickName(id),
+            //LastReadMessage = GenerateMessageEntity(lastmessageID),
+            Role = ChatRole.Admin,
+            User = user,
+            //Chat = GenerateChatEntity(chatID),
+            UserKeyId = userKeyID
+
+        };
+    }
+
+    public static UserChatDto GenerateUserChatDto(IMapper mapper, UserEntity user, Guid id = new ())
+    {
+        var userChatEntity = GenerateUserChatEntity(user, id);
+
+        return mapper.Map<UserChatDto>(userChatEntity);
+    }
+
+    private static string GenerateNickName(Guid id = new())
+    {
+        return $"nick{id}";
+    }
+
+    #endregion
 }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/DataGenerator.cs
@@ -176,7 +176,7 @@ public static class DataGenerator
         return new AttachmentEntity
         {
             Id = id,
-            Type = AttachmentType.ProfilePicture,
+            Type = AttachmentType.MessageAttachment,
             Extension = GenerateExtension(),
             Path = fileNameAndPath.Item2,
             publicName = fileNameAndPath.Item1
@@ -208,12 +208,12 @@ public static class DataGenerator
             NickName = GenerateNickName(id),
             Role = ChatRole.Admin,
             User = user,
-            //Chat = GenerateChatEntity(chatID),
+            Chat = GenerateChatEntity(chatID),
             UserKeyId = userKey.Id
 
         };
 
-        //userChatEntity.LastReadMessage = GenerateMessageEntity(userChatEntity, lastmessageID);
+        userChatEntity.LastReadMessage = GenerateMessageEntity(userChatEntity, lastmessageID);
 
         return userChatEntity;
     }
@@ -239,7 +239,10 @@ public static class DataGenerator
         var userCreatedID = Guid.NewGuid();
         var attachmentID = Guid.NewGuid();
         var passwordContainerID = Guid.NewGuid();
-        var attachment = GenerateAttachmentEntity(attachmentID);
+        var attachment = GenerateAttachmentEntity(Guid.NewGuid());
+        var userTest = userChat.User;
+        var passwordContainerTest = GeneratePasswordContainerEntity(userChat.ChatId, passwordContainerID);
+
         return new MessageEntity
         {
             Id = id,
@@ -249,10 +252,10 @@ public static class DataGenerator
             UserCreatedId = userChat.UserId,
             AttachmentId = attachmentID,
             PasswordContainerId = passwordContainerID,
-            //Chat = GenerateChatEntity(chatID),
-            UserCreated = GenerateUserEntity("gmail.com", userCreatedID),
+            Chat = userChat.Chat,
+            UserCreated = userTest,
             Attachments = new List<AttachmentEntity> { attachment },
-            PasswordContainer = GeneratePasswordContainerEntity(userChat.ChatId,passwordContainerID)
+            PasswordContainer = passwordContainerTest
         };
     }
 
@@ -328,7 +331,24 @@ public static class DataGenerator
 
     #region Generate Chat related data
 
-    //Methods in ChatEntity branch
+    public static ChatEntity GenerateChatEntity(Guid id = new(), Guid thumbnailID = new())
+    {
+        return new ChatEntity()
+        {
+            Id = id,
+            Name = $"chat{id}",
+            ThumbnailId = thumbnailID,
+            Thumbnail = GenerateAttachmentEntity(thumbnailID)
+
+        };
+    }
+
+    public static ChatDto GenerateChatDto(IMapper mapper, Guid id = new(), Guid thumbnailID = new())
+    {
+        var chatEntity = GenerateChatEntity(id);
+
+        return mapper.Map<ChatDto>(chatEntity);
+    }
 
     #endregion
 }

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/TestHelper.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/TestHelper.cs
@@ -23,11 +23,11 @@ public class TestHelper
     }
 
     #region Fill tables
-    public async Task FillUsersTable(List<Guid> idsToAdd)
+    public async Task FillUsersTable(List<Guid> idsToAdd, List<string> domainsToAdd)
     {
-        foreach (var id in idsToAdd)
+        for(int i = 0; i < idsToAdd.Count; i++)
         {
-            var newUser = GenerateUserEntity(id);
+            var newUser = GenerateUserEntity(domainsToAdd[i], idsToAdd[i]);
 
             await _testDbContext
                 .Users.AddAsync(newUser);

--- a/pimi-connect-api/pimi-connect-api.UnitTests/Shared/TestHelper.cs
+++ b/pimi-connect-api/pimi-connect-api.UnitTests/Shared/TestHelper.cs
@@ -32,7 +32,8 @@ public class TestHelper
             await _testDbContext
                 .Users.AddAsync(newUser);
         }
-        
+
+        ;
         await _testDbContext.SaveChangesAsync();
         _testDbContext.ChangeTracker.Clear();
     }


### PR DESCRIPTION
https://app.clickup.com/t/8693hfgcm
In GenerateMessageEntity Attachments is commented -> Przy usuwaniu użytkownika:  modyfikacja lub usunięcie na tabeli "Messages" narusza klucz obcy "FK_Attachments_Messages_MessageEntityId" tabeli "Attachments" 
DETAIL: Klucz (Id)=(70f4dd44-f049-44c4-ac6a-4bfdd6375399) ma wciąż odwołanie w tabeli "Attachments".